### PR TITLE
Deactivate ysql to start actually putting load up with ycql and yedis

### DIFF
--- a/manifests/production/vars.yml
+++ b/manifests/production/vars.yml
@@ -1,13 +1,5 @@
 ---
-master_gflags:
-  default_memory_limit_to_ram_ratio: 0.85
-  enable_ysql: false # TODO
-  max_log_size: 256
-  minloglevel: 0
-  placement_cloud: aws
-  placement_region: us-west-2
-  stop_logging_if_full_disk: true
-tserver_gflags:
+common_gflags:
   default_memory_limit_to_ram_ratio: 0.85
   enable_ysql: false # TODO should be true or not even here
   max_log_size: 256

--- a/manifests/production/yugabyte.yml
+++ b/manifests/production/yugabyte.yml
@@ -29,7 +29,7 @@ instance_groups:
         consumes: { yb-master: { from: yb-master-provider } }
         provides: { yb-master: { as: yb-master-provider } }
         properties:
-          gflags: ((master_gflags))
+          gflags: ((common_gflags))
 
   - name: tserver
     azs: [us-west-2a, us-west-2b, us-west-2c]
@@ -44,7 +44,7 @@ instance_groups:
         consumes: { yb-master: { from: yb-master-provider } }
         provides: { yb-tserver: { as: yb-tserver-provider } }
         properties:
-          gflags: ((tserver_gflags))
+          gflags: ((common_gflags))
           server_broadcast_addresses_port: 9101
           rpc_bind_addresses_port: 9101
 


### PR DESCRIPTION
Having difficulties with getting postgres initdb to play nice, so going to disable ysql for now and just focus on ycql and yedis

```log
tserver/41f012f3-5ae1-4855-9e08-28b7f9118636: stdout | post_install.sh was already run (marker at /var/vcap/packages/yugabyte/.post_install.sh.completed)
tserver/41f012f3-5ae1-4855-9e08-28b7f9118636: stdout | 
tserver/41f012f3-5ae1-4855-9e08-28b7f9118636: stdout | ==> /var/vcap/sys/log/yb-tserver/yb-tserver.stderr.log <==
tserver/41f012f3-5ae1-4855-9e08-28b7f9118636: stdout |     @           0x410513  yb::tserver::(anonymous namespace)::TabletServerMain()
tserver/41f012f3-5ae1-4855-9e08-28b7f9118636: stdout |     @     0x7f6474baa825 __libc_start_main
tserver/41f012f3-5ae1-4855-9e08-28b7f9118636: stdout |     @           0x40f829 _start
tserver/41f012f3-5ae1-4855-9e08-28b7f9118636: stdout |     @                0x0 (unknown)
tserver/41f012f3-5ae1-4855-9e08-28b7f9118636: stdout | Segmentation fault
tserver/41f012f3-5ae1-4855-9e08-28b7f9118636: stdout | no data was returned by command ""/var/vcap/data/packages/yugabyte/8794e053a0449c6423cff56922e1671a55201ee6/postgres/bin/postgres" -V"
tserver/41f012f3-5ae1-4855-9e08-28b7f9118636: stdout | The program "postgres" is needed by initdb but was not found in the
tserver/41f012f3-5ae1-4855-9e08-28b7f9118636: stdout | same directory as "/var/vcap/data/packages/yugabyte/8794e053a0449c6423cff56922e1671a55201ee6/postgres/bin/initdb".
tserver/41f012f3-5ae1-4855-9e08-28b7f9118636: stdout | Check your installation.

```

also:

- shuffles the manifest around again
- consolidate into common gflags
- bump the update and canary timeout period on main manifest