### PR TITLE
Remove NET capabilities section

### DIFF
--- a/jobs/yb-ctl/templates/bpm.erb.yml
+++ b/jobs/yb-ctl/templates/bpm.erb.yml
@@ -9,6 +9,3 @@ processes:
       - --data_dir=/var/vcap/store/yb-ctl/yugabyte-data/
       - --verbose
       - --v=<%= p("v_level") %>
-
-    capabilities:
-      - NET_BIND_SERVICE

--- a/jobs/yb-master/templates/bpm.erb.yml
+++ b/jobs/yb-master/templates/bpm.erb.yml
@@ -6,6 +6,3 @@ processes:
     ephemeral_disk: false
     args:
       - --flagfile=/var/vcap/jobs/yb-master/master.conf
-
-    capabilities:
-      - NET_BIND_SERVICE

--- a/jobs/yb-tserver/templates/bpm.erb.yml
+++ b/jobs/yb-tserver/templates/bpm.erb.yml
@@ -6,6 +6,3 @@ processes:
     ephemeral_disk: false
     args:
       - --flagfile=/var/vcap/jobs/yb-tserver/tserver.conf
-
-    capabilities:
-      - NET_BIND_SERVICE

--- a/jobs/yugabyted/templates/bpm.erb.yml
+++ b/jobs/yugabyted/templates/bpm.erb.yml
@@ -9,6 +9,3 @@ processes:
     - --data_dir=/var/vcap/store/yugabyted/yugabyte-data/
     - --log_dir=/var/vcap/sys/log/yugabyted
     - --bind_ip=<%= spec.address %>
-
-    capabilities:
-      - NET_BIND_SERVICE


### PR DESCRIPTION
there's no need for this since we don't bind on anything below port 1024

https://starkandwayne.com/blog/the-capable-kernel-an-introduction-to-linux-capabilities/

>CAP_NET_BIND_SERVICE - Allows binding of so-called "privileged" ports (those below 1024).

closes https://github.com/aegershman/yugabyte-boshrelease/issues/57