### PR TITLE
no ephemeral disk declarations, get outta here

### DIFF
--- a/jobs/yb-master/templates/bpm.erb.yml
+++ b/jobs/yb-master/templates/bpm.erb.yml
@@ -3,6 +3,5 @@ processes:
   - name: yb-master
     executable: /var/vcap/packages/yugabyte/bin/yb-master
     persistent_disk: true
-    ephemeral_disk: false
     args:
       - --flagfile=/var/vcap/jobs/yb-master/master.conf

--- a/jobs/yb-tserver/templates/bpm.erb.yml
+++ b/jobs/yb-tserver/templates/bpm.erb.yml
@@ -3,6 +3,5 @@ processes:
   - name: yb-tserver
     executable: /var/vcap/packages/yugabyte/bin/yb-tserver
     persistent_disk: true
-    ephemeral_disk: false
     args:
       - --flagfile=/var/vcap/jobs/yb-tserver/tserver.conf

--- a/jobs/yugabyted/templates/bpm.erb.yml
+++ b/jobs/yugabyted/templates/bpm.erb.yml
@@ -3,7 +3,6 @@ processes:
   - name: yugabyted
     executable: /var/vcap/packages/yugabyte/bin/yugabyted
     persistent_disk: true
-    ephemeral_disk: false
     args:
     - start
     - --data_dir=/var/vcap/store/yugabyted/yugabyte-data/


### PR DESCRIPTION
closes https://github.com/aegershman/yugabyte-boshrelease/issues/62

see:
https://github.com/cloudfoundry/bpm-release/blob/master/src/bpm/config/job_config.go
https://bosh.io/docs/bpm/config/