### PR TITLE
Consolidate addressing to use DNS rather than individual instances

### DIFF
--- a/jobs/yb-master/templates/config/master.conf.erb
+++ b/jobs/yb-master/templates/config/master.conf.erb
@@ -1,6 +1,6 @@
 --fs_data_dirs=/var/vcap/store/yb-master
 --log_dir=/var/vcap/sys/log/yb-master
---master_addresses=<%= link("yb-master").instances.map { |instance| "#{instance.address}:7100" }.join(",") %>
+--master_addresses=<%= link("yb-master").address %>:7100
 --placement_zone=<%= spec.az %>
 --replication_factor=<%= p("replication_factor", link("yb-master").instances.length) %>
 --rpc_bind_addresses=<%= spec.address %>

--- a/jobs/yb-tserver/templates/config/tserver.conf.erb
+++ b/jobs/yb-tserver/templates/config/tserver.conf.erb
@@ -3,7 +3,7 @@
 --placement_zone=<%= spec.az %>
 --rpc_bind_addresses=<%= spec.address %>:<%= p("rpc_bind_addresses_port") %>
 --server_broadcast_addresses=<%= spec.address %>:<%= p("server_broadcast_addresses_port") %>
---tserver_master_addrs=<%= link("yb-master").instances.map { |instance| "#{instance.address}:7100" }.join(",") %>
+--tserver_master_addrs=<%= link("yb-master").address %>:7100
 
 <% if p("tls.use_client_to_server_encryption") -%>
 --allow_insecure_connections=<%= p("tls.allow_insecure_connections") %>

--- a/manifests/operators/development/vars.yml
+++ b/manifests/operators/development/vars.yml
@@ -2,6 +2,8 @@
 # loaded last in testing tooling to be used
 # for experimentation while developing this release
 ---
+master_instances: 3
 tserver_allow_insecure_connections: true
+tserver_instances: 3
 use_client_to_server_encryption: true
 yugabyte_server_tls_update_mode: overwrite


### PR DESCRIPTION
Quick test: judging by some things I've seen on the k8s deployment we should just be able to use a single dns address instead of individual nodes, right?

based off of this:
- https://www.slideshare.net/YugaByte/running-stateful-apps-on-kubernetes
- YugaByte -- yugabyte-db -- 2158

where someone configures their setup using this (notice the second line is commented out):

```sh
            - "--master_addresses=yb-master.$(NAMESPACE).svc.cluster.local:7100"
#            - "--master_addresses=yb-master-0.yb-masters.$(NAMESPACE).svc.cluster.local:7100,yb-master-1.yb-masters.$(NAMESPACE).svc.cluster.local:7100,yb-master-2.yb-masters.$(NAMESPACE).svc.cluster.local:7100"
```

might, might, and only _maybe_ related to:
- https://github.com/aegershman/yugabyte-boshrelease/issues/53
- https://github.com/aegershman/yugabyte-boshrelease/issues/65

it'll take two seconds to test, hang on