### PR TITLE
server dump info path based on yugabyted

### DIFF
--- a/jobs/yb-master/templates/config/master.conf.erb
+++ b/jobs/yb-master/templates/config/master.conf.erb
@@ -1,6 +1,6 @@
 --fs_data_dirs=/var/vcap/store/yb-master
 --log_dir=/var/vcap/sys/log/yb-master
---server_dump_info_path=/var/vcap/store/yb-master/master-info
+--server_dump_info_path=/var/vcap/sys/log/yb-master/master-info
 --logtostderr=<%= p("logtostderr") %>
 --max_log_size=<%= p("max_log_size") %>
 --minloglevel=<%= p("minloglevel") %>

--- a/jobs/yb-tserver/templates/config/tserver.conf.erb
+++ b/jobs/yb-tserver/templates/config/tserver.conf.erb
@@ -1,6 +1,6 @@
 --fs_data_dirs=/var/vcap/store/yb-tserver
 --log_dir=/var/vcap/sys/log/yb-tserver
---server_dump_info_path=/var/vcap/store/yb-tserver/tserver-info
+--server_dump_info_path=/var/vcap/sys/log/yb-tserver/tserver-info
 --logtostderr=<%= p("logtostderr") %>
 --max_log_size=<%= p("max_log_size") %>
 --minloglevel=<%= p("minloglevel") %>


### PR DESCRIPTION
- https://github.com/yugabyte/yugabyte-db/blob/master/bin/yugabyted#L395
- https://github.com/yugabyte/yugabyte-db/blob/a5a0f7dafde1756f9dd3015ddcd5e78143a30b12/src/yb/server/server_base_options.cc#L71-L80

This doesn't make the server-info populate, but it does dump some interesting information. Plus yugabyted does it, why not us?

when not setting path, here's all the `*dump*` files:

```
tserver/45e09a6a-126e-4d91-93b9-8912aba928c7:/var/vcap# find . -iname "*dump*"
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/bin/pg_waldump
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/bin/ysql_dumpall
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/bin/ysql_dump
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/bin/yb-pbc-dump
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/bin/sst_dump
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/bin/log-dump
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/json/tests/test_dump.pyc
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/json/tests/test_dump.pyo
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/json/tests/test_dump.py
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/sqlite3/dump.py
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/sqlite3/test/dump.py
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/sqlite3/test/dump.pyc
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/sqlite3/test/dump.pyo
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/sqlite3/dump.pyc
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/sqlite3/dump.pyo
```

all "*info* files

```log
tserver/45e09a6a-126e-4d91-93b9-8912aba928c7:/var/vcap# find . -iname "*info*"
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/lib/yb/libversion_info_proto.so
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/share/information_schema.sql
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/share/extension/sslinfo--1.2.sql
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/share/extension/sslinfo--unpackaged--1.0.sql
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/share/extension/sslinfo.control
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/share/extension/sslinfo--1.1--1.2.sql
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/share/extension/sslinfo--1.0--1.1.sql
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/lib/sslinfo.so
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/include/informix
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/include/server/common/config_info.h
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/include/server/lib/stringinfo.h
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/include/server/getaddrinfo.h
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/include/server/optimizer/restrictinfo.h
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/include/server/optimizer/joininfo.h
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/include/ecpg_informix.h
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/linuxbrew/Cellar/glibc/2.23/share/zoneinfo
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/linuxbrew/Cellar/ncurses/6.1/share/terminfo
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/linuxbrew/Cellar/ncurses/6.1/share/terminfo/i/infoton
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/linuxbrew/Cellar/ncurses/6.1/share/terminfo/a/addrinfo
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/ui/lib/com.sun.xml.fastinfoset.FastInfoset-1.2.16.jar
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/ui/conf/db/migration/default/V11__Alter_Task_Info.sql
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/site-packages/pip-1.5.2-py2.7.egg/EGG-INFO
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/site-packages/pip-1.5.2-py2.7.egg/EGG-INFO/PKG-INFO
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/wsgiref.egg-info
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/lib-dynload/Python-2.7.6-py2.7.egg-info
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/distutils/command/install_egg_info.pyc
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/distutils/command/install_egg_info.pyo
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/distutils/command/install_egg_info.py
./data/sys/log/yb-tserver/yb-tserver.c476d9d0-dde9-4aad-95c5-b36a71b99d90.invalid-user.log.INFO.20200316-151638.6
./data/sys/log/yb-tserver/yb-tserver.INFO
tserver/45e09a6a-126e-4d91-93b9-8912aba928c7:/var/vcap# 
```

all "*server* named files

```log
tserver/45e09a6a-126e-4d91-93b9-8912aba928c7:/var/vcap# find . -iname "*server*"
./bosh/etc/ntpserver
./store/yb-tserver
./store/yb-tserver/yb-data/tserver
./jobs/yb-tserver
./monit/job/0006_yb-tserver.monitrc
./data/yb-tserver
./data/packages/bosh-dns/8fd4dfeca55c66de34503a2c8511dba25db6c13d/bin/bosh-dns-nameserverconfig
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/lib/yb/libtserver_admin_proto.so
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/lib/yb/libtserver_test_util.so
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/lib/yb/libyb-redisserver-test.so
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/lib/yb/libserver_process.so
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/lib/yb/libtserver.so
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/lib/yb/libtserver_util.so
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/lib/yb/libtserver_service_proto.so
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/lib/yb/libserver_common.so
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/lib/yb/libtserver_proto.so
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/lib/yb/libserver_base_proto.so
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/include/server
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/include/server/catalog/pg_foreign_server.h
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/postgres/include/server/catalog/pg_foreign_server_d.h
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/ui/lib/com.typesafe.play.play-netty-server_2.11-2.5.3.jar
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/ui/lib/com.typesafe.play.play-server_2.11-2.5.3.jar
./data/packages/yugabyte/0a4f8c5c4fc4e0103d5329653f99ffe7f2f84b4e/bin/yb-tserver
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/SimpleXMLRPCServer.pyc
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/DocXMLRPCServer.py
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/DocXMLRPCServer.pyc
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/test/test_httpservers.py
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/test/test_socketserver.pyc
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/test/test_socketserver.py
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/test/test_SimpleHTTPServer.py
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/test/test_httpservers.pyc
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/test/test_SimpleHTTPServer.pyo
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/test/test_SimpleHTTPServer.pyc
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/test/test_socketserver.pyo
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/test/test_httpservers.pyo
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/wsgiref/simple_server.pyo
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/wsgiref/simple_server.py
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/wsgiref/simple_server.pyc
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/CGIHTTPServer.pyc
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/SimpleHTTPServer.pyo
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/BaseHTTPServer.pyo
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/SocketServer.pyo
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/SimpleXMLRPCServer.pyo
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/SocketServer.py
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/DocXMLRPCServer.pyo
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/SimpleHTTPServer.py
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/SocketServer.pyc
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/SimpleXMLRPCServer.py
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/CGIHTTPServer.py
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/CGIHTTPServer.pyo
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/BaseHTTPServer.pyc
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/BaseHTTPServer.py
./data/packages/python-2.7/5a9f2831c91ca6dfe2bda7d6141388e80df9ae86/lib/python2.7/SimpleHTTPServer.pyc
./data/jobs/yb-tserver
./data/jobs/yb-tserver/f84cb3c44a183ffb53bef188dbed93cfc01f147f/config/tserver.conf
./data/jobs/bosh-dns/8054651b1721501a47035ea987f61ca5577e2fef/config/health_server_config.json
./data/jobs/bosh-dns/8054651b1721501a47035ea987f61ca5577e2fef/config/certs/api/server.key
./data/jobs/bosh-dns/8054651b1721501a47035ea987f61ca5577e2fef/config/certs/api/server_ca.crt
./data/jobs/bosh-dns/8054651b1721501a47035ea987f61ca5577e2fef/config/certs/api/server.crt
./data/jobs/bosh-dns/8054651b1721501a47035ea987f61ca5577e2fef/config/certs/health/server.key
./data/jobs/bosh-dns/8054651b1721501a47035ea987f61ca5577e2fef/config/certs/health/server_ca.crt
./data/jobs/bosh-dns/8054651b1721501a47035ea987f61ca5577e2fef/config/certs/health/server.crt
./data/sys/log/yb-tserver
./data/sys/log/yb-tserver/yb-tserver.c476d9d0-dde9-4aad-95c5-b36a71b99d90.invalid-user.log.INFO.20200316-151638.6
./data/sys/log/yb-tserver/yb-tserver.INFO
./data/sys/log/yb-tserver/yb-tserver.stderr.log
./data/sys/log/yb-tserver/yb-tserver.stdout.log
./data/sys/run/bpm/yb-tserver
./data/sys/run/bpm/yb-tserver/yb-tserver.pid
./data/sys/run/yb-tserver
./data/bpm/runc/bpm-yb-tserver
./data/bpm/locks/job-bpm-yb-tserver.2eyb-tserver.lock
./data/bpm/bundles/yb-tserver
./data/bpm/bundles/yb-tserver/yb-tserver
./data/bpm/bundles/yb-tserver/yb-tserver/rootfs/var/vcap/data/yb-tserver
./data/bpm/bundles/yb-tserver/yb-tserver/rootfs/var/vcap/jobs/yb-tserver
./data/bpm/bundles/yb-tserver/yb-tserver/rootfs/var/vcap/store/yb-tserver
./data/bpm/bundles/yb-tserver/yb-tserver/rootfs/var/vcap/sys/log/yb-tserver
tserver/45e09a6a-126e-4d91-93b9-8912aba928c7:/var/vcap# 
```

and finally, the "dump_info" path from gflags on tserver (notice it's empty):

```log
--server_dump_info_format=json
--server_dump_info_path=
```

