### PR TITLE
stop on parent termination testing for development

### DIFF
--- a/manifests/operators/development/vars.yml
+++ b/manifests/operators/development/vars.yml
@@ -11,3 +11,9 @@ syslog_port: 5514
 syslog_tls_enabled: false
 tserver_instances: 1
 tserver_stderrthreshold: 0
+master_gflags:
+  # TODO testing
+  stop_on_parent_termination: true
+tserver_gflags:
+  # TODO testing
+  stop_on_parent_termination: true


### PR DESCRIPTION
- https://github.com/yugabyte/yugabyte-db/blob/master/bin/yugabyted#L377
- https://github.com/yugabyte/yugabyte-db/blob/c46c6dda68e16adb663748e0faae63b1f843d036/src/yb/util/init.cc#L57

What is this? Why is it here? Is it important? Why is it defined in yugabyted? etc.

Experimenting by including it in the dev vars file for a while