### PR TITLE
Make stop_on_parent_termination a top-level configuration option

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,6 +69,7 @@ tasks:
           -o manifests/operators/logging/stderrthreshold.yml \
           -o manifests/operators/placement-options.yml \
           -o manifests/operators/sample-apps/cassandrakeyvalue.yml \
+          -o manifests/operators/stop_on_parent_termination.yml \
           -o manifests/operators/tserver-rpc-bind-port.yml \
           -l manifests/operators/sample-apps/vars.yml \
           -l manifests/vars.yml \

--- a/jobs/yb-master/spec
+++ b/jobs/yb-master/spec
@@ -99,6 +99,10 @@ properties:
       IMPORTANT: This value must match on all yb-master and yb-tserver configurations of a YugabyteDB cluster.
     default: 8
 
+  stop_on_parent_termination:
+    description: When specified, this process will terminate when parent process terminates. Linux-only.
+    default: false
+
   placement_cloud:
     description: Specifies the name of the cloud where this instance is deployed.
     default: cloud1

--- a/jobs/yb-master/templates/config/master.conf.erb
+++ b/jobs/yb-master/templates/config/master.conf.erb
@@ -22,6 +22,8 @@
 --yb_num_shards_per_tserver=<%= p("yb_num_shards_per_tserver") %>
 --ysql_num_shards_per_tserver=<%= p("ysql_num_shards_per_tserver") %>
 
+--stop_on_parent_termination=<%= p("stop_on_parent_termination") %>
+
 --placement_cloud=<%= p("placement_cloud") %>
 --placement_region=<%= p("placement_region") %>
 --placement_zone=<%= p("placement_zone", spec.az) %>

--- a/jobs/yb-tserver/spec
+++ b/jobs/yb-tserver/spec
@@ -103,6 +103,10 @@ properties:
       IMPORTANT: This value must match on all yb-master and yb-tserver configurations of a YugabyteDB cluster.
     default: 8
 
+  stop_on_parent_termination:
+    description: When specified, this process will terminate when parent process terminates. Linux-only.
+    default: false
+
   ycql.databases.superusers:
     description: |
       until we get to putting a more fine-grained RBAC model in place

--- a/jobs/yb-tserver/templates/config/tserver.conf.erb
+++ b/jobs/yb-tserver/templates/config/tserver.conf.erb
@@ -25,6 +25,8 @@
 --yb_num_shards_per_tserver=<%= p("yb_num_shards_per_tserver") %>
 --ysql_num_shards_per_tserver=<%= p("ysql_num_shards_per_tserver") %>
 
+--stop_on_parent_termination=<%= p("stop_on_parent_termination") %>
+
 --placement_cloud=<%= p("placement_cloud") %>
 --placement_region=<%= p("placement_region") %>
 --placement_zone=<%= p("placement_zone", spec.az) %>

--- a/manifests/operators/development/vars.yml
+++ b/manifests/operators/development/vars.yml
@@ -6,14 +6,9 @@ callhome_enabled: false
 enable_ysql: false
 master_instances: 1
 master_stderrthreshold: 0
+stop_on_parent_termination: true
 syslog_address: q-s0.docker.services-network.splunk.bosh
 syslog_port: 5514
 syslog_tls_enabled: false
 tserver_instances: 1
 tserver_stderrthreshold: 0
-master_gflags:
-  # TODO testing
-  stop_on_parent_termination: true
-tserver_gflags:
-  # TODO testing
-  stop_on_parent_termination: true

--- a/manifests/operators/stop_on_parent_termination.yml
+++ b/manifests/operators/stop_on_parent_termination.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /instance_groups/name=master/jobs/name=yb-master/properties?/stop_on_parent_termination?
+  value: ((stop_on_parent_termination))
+
+- type: replace
+  path: /instance_groups/name=tserver/jobs/name=yb-tserver/properties?/stop_on_parent_termination?
+  value: ((stop_on_parent_termination))


### PR DESCRIPTION
Even if it's just testing, it's more professional to do it this way; if it's good enough for yugabyted, why not make it optional here?

Continuation of https://github.com/aegershman/yugabyte-boshrelease/pull/164

```log
I0316 15:02:39.424892     6 server_base.cc:310] Dumped server information to /var/vcap/store/yb-master/master-info

From master:

master/05736413-ac5d-4fba-86c6-705f303e26ff:~# cat /var/vcap/store/yb-master/master-info 
{
    "node_instance": {
        "permanent_uuid": "65b79cdb4fcc47b695820e51fe8d854c",
        "instance_seqno": 1584370959419910
    },
    "bound_rpc_addresses": [
        {
            "host": "10.156.89.11",
            "port": 7100
        }
    ],
    "bound_http_addresses": [
        {
            "host": "10.156.89.11",
            "port": 7000
        }
    ],
    "version_info": {
        "git_hash": "d16f8e36d68311b1d9130ea28cec9e338b9f870e",
        "build_hostname": "scheduler.c.yugabyte.internal",
        "build_timestamp": "10 Mar 2020 06:23:36 UTC",
        "build_username": "centos",
        "build_clean_repo": true,
        "build_id": "",
        "build_type": "RELEASE",
        "version_number": "2.1.2.0",
        "build_number": "10"
    }
}master/05736413-ac5d-4fba-86c6-705f303e26ff:~# 
```