### PR TITLE
Conditionalize YSQL init especially master-auto-init

### DIFF
--- a/jobs/yb-master/templates/config/master.conf.erb
+++ b/jobs/yb-master/templates/config/master.conf.erb
@@ -15,9 +15,11 @@
 --webserver_interface=<%= spec.address %>
 --webserver_port=<%= p("webserver_port") %>
 
+<% if p("enable_ysql") -%>
 --enable_ysql=<%= p("enable_ysql") %>
 --initial_sys_catalog_snapshot_path=/var/vcap/packages/yugabyte/share/initial_sys_catalog_snapshot
---master_auto_run_initdb=true
+--master_auto_run_initdb=<%= p("enable_ysql") %>
+<% end -%>
 
 --default_memory_limit_to_ram_ratio=<%= p("default_memory_limit_to_ram_ratio") %>
 


### PR DESCRIPTION
the flags might be a little too overzealous... unfortunately leaving master-auto-init as true might still cause it to try and initialize initdb, so this might need to be off

quick continuation of https://github.com/aegershman/yugabyte-boshrelease/pull/170