### PR TITLE
Minor opsfiles cleanup for development testing before cutting release

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,16 +62,11 @@ tasks:
       - |
         bosh -d yugabyte deploy manifests/yugabyte.yml \
           -o manifests/operators/development/create-release-from-local.yml \
-          -o manifests/operators/development/enable-ysql.yml \
           -o manifests/operators/gflags.yml \
-          -o manifests/operators/logging/callhome_enabled.yml \
           -o manifests/operators/logging/enable-syslog-forwarder.yml \
           -o manifests/operators/logging/stderrthreshold.yml \
-          -o manifests/operators/logging/ysql_log_statement.yml \
-          -o manifests/operators/performance-tuning/durable_wal_write.yml \
           -o manifests/operators/placement-options.yml \
           -o manifests/operators/sample-apps/cassandrakeyvalue.yml \
-          -o manifests/operators/stop_on_parent_termination.yml \
           -o manifests/operators/tserver-rpc-bind-port.yml \
           -l manifests/operators/sample-apps/vars.yml \
           -l manifests/vars.yml \

--- a/manifests/operators/development/vars.yml
+++ b/manifests/operators/development/vars.yml
@@ -2,15 +2,10 @@
 # loaded last in testing tooling to be used
 # for experimentation while developing this release
 ---
-callhome_enabled: false
-durable_wal_write: true
-enable_ysql: false
 master_instances: 1
 master_stderrthreshold: 0
-stop_on_parent_termination: true
 syslog_address: q-s0.docker.services-network.splunk.bosh
 syslog_port: 5514
 syslog_tls_enabled: false
 tserver_instances: 1
 tserver_stderrthreshold: 0
-ysql_log_statement: all


### PR DESCRIPTION
Just trying to test this out by making it more closely resemblant of what is currently in use in our trial environments