### PR TITLE
TLS evaluation redux

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,8 +67,10 @@ tasks:
           -o manifests/operators/logging/stderrthreshold.yml \
           -o manifests/operators/placement-options.yml \
           -o manifests/operators/sample-apps/cassandrakeyvalue.yml \
+          -o manifests/operators/tls/enable-server-to-server-encryption.yml \
           -o manifests/operators/tserver-rpc-bind-port.yml \
           -l manifests/operators/sample-apps/vars.yml \
+          -l manifests/operators/tls/vars.yml \
           -l manifests/vars.yml \
           -l manifests/versions.yml \
           -l manifests/operators/development/vars.yml \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,6 +67,7 @@ tasks:
           -o manifests/operators/logging/stderrthreshold.yml \
           -o manifests/operators/placement-options.yml \
           -o manifests/operators/sample-apps/cassandrakeyvalue.yml \
+          -o manifests/operators/tls/enable-client-to-server-encryption.yml \
           -o manifests/operators/tls/enable-server-to-server-encryption.yml \
           -o manifests/operators/tserver-rpc-bind-port.yml \
           -l manifests/operators/sample-apps/vars.yml \

--- a/manifests/operators/development/vars.yml
+++ b/manifests/operators/development/vars.yml
@@ -9,3 +9,4 @@ syslog_port: 5514
 syslog_tls_enabled: false
 tserver_instances: 1
 tserver_stderrthreshold: 0
+tserver_allow_insecure_connections: true

--- a/manifests/operators/development/vars.yml
+++ b/manifests/operators/development/vars.yml
@@ -9,5 +9,3 @@ syslog_port: 5514
 syslog_tls_enabled: false
 tserver_instances: 1
 tserver_stderrthreshold: 0
-master_allow_insecure_connections: true
-tserver_allow_insecure_connections: true

--- a/manifests/operators/development/vars.yml
+++ b/manifests/operators/development/vars.yml
@@ -9,3 +9,5 @@ syslog_port: 5514
 syslog_tls_enabled: false
 tserver_instances: 1
 tserver_stderrthreshold: 0
+master_allow_insecure_connections: true
+tserver_allow_insecure_connections: true

--- a/manifests/operators/tls/vars.yml
+++ b/manifests/operators/tls/vars.yml
@@ -4,5 +4,5 @@ master_allow_insecure_connections: false
 tserver_allow_insecure_connections: false
 use_client_to_server_encryption: true
 use_node_to_node_encryption: true
-yugabyte_server_tls_common_name: yugabyte-boshrelease
+yugabyte_server_tls_common_name: rootCA
 yugabyte_server_tls_update_mode: converge


### PR DESCRIPTION
It's possible that the node-to-node and client-to-node TLS communications aren't working exactly as intended (see https://github.com/aegershman/yugabyte-boshrelease/issues/138). This evaluates a few changes:

- having the intermediate CN be equal to the CA CN
- have node to node encryption on by default
- re-evaluate client-to-node encryption