### PR TITLE
Pull auxiliary boshreleases from bosh.io

### DIFF
--- a/manifests/operators/logging/enable-syslog-forwarder.yml
+++ b/manifests/operators/logging/enable-syslog-forwarder.yml
@@ -4,6 +4,8 @@
   value:
     name: syslog
     version: ((syslog_release_version))
+    url: https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=((syslog_release_version))
+    sha1: ((syslog_release_sha1))
 
 - type: replace
   path: /addons?/-

--- a/manifests/operators/use-offline-boshreleases.yml
+++ b/manifests/operators/use-offline-boshreleases.yml
@@ -1,0 +1,15 @@
+---
+- type: remove
+  path: /releases/name=yugabyte/url?
+- type: remove
+  path: /releases/name=yugabyte/sha1?
+
+- type: remove
+  path: /releases/name=bpm/url?
+- type: remove
+  path: /releases/name=bpm/sha1?
+
+- type: remove
+  path: /releases/name=syslog?/url?
+- type: remove
+  path: /releases/name=syslog?/sha1?

--- a/manifests/versions.yml
+++ b/manifests/versions.yml
@@ -1,6 +1,7 @@
 ---
 bpm_sha1: c956394fce7e74f741e4ae8c256b480904ad5942
 bpm_version: 1.1.8
+syslog_release_sha1: e2649e48c49aedcbd0ff96b00f56b028682f1dd6
 syslog_release_version: 11.6.1
 yugabyte_boshrelease_sha1: 2bf6c58a5bbddd8e98d4d980a6d6a3c2fd1b7d74
 yugabyte_boshrelease_version: 0.0.9

--- a/manifests/versions.yml
+++ b/manifests/versions.yml
@@ -1,6 +1,6 @@
 ---
-bpm_sha1: c956394fce7e74f741e4ae8c256b480904ad5942
-bpm_version: 1.1.8
+bpm_sha1: 5bad6161dbbcf068830a100b6a76056fe3b99bc8
+bpm_version: 1.1.6
 syslog_release_sha1: e2649e48c49aedcbd0ff96b00f56b028682f1dd6
 syslog_release_version: 11.6.1
 yugabyte_boshrelease_sha1: 2bf6c58a5bbddd8e98d4d980a6d6a3c2fd1b7d74

--- a/manifests/versions.yml
+++ b/manifests/versions.yml
@@ -1,5 +1,6 @@
 ---
-bpm_version: 1.1.6
+bpm_sha1: c956394fce7e74f741e4ae8c256b480904ad5942
+bpm_version: 1.1.8
 syslog_release_version: 11.6.1
 yugabyte_boshrelease_sha1: 2bf6c58a5bbddd8e98d4d980a6d6a3c2fd1b7d74
 yugabyte_boshrelease_version: 0.0.9

--- a/manifests/yugabyte.yml
+++ b/manifests/yugabyte.yml
@@ -10,6 +10,8 @@ releases:
     sha1: ((yugabyte_boshrelease_sha1))
   - name: bpm
     version: ((bpm_version))
+    sha1: ((bpm_sha1))
+    url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=((bpm_version))
 
 addons:
   - name: bpm


### PR DESCRIPTION
In order to get the latest boshreleases available on foundations which don't already have precompiled versions of the releases available, we should have the boshreleases yanked from bosh.io instead of assuming they're already available as releases on the same director