### PR TITLE
Remove opsfile for removing bosh dns features

### DIFF
--- a/manifests/operators/rm-bosh-dns-features.yml
+++ b/manifests/operators/rm-bosh-dns-features.yml
@@ -1,9 +1,0 @@
----
-- type: remove
-  path: /features?/randomize_az_placement?
-
-- type: remove
-  path: /features?/use_dns_addresses?
-
-- type: remove
-  path: /features?/use_short_dns_addresses?


### PR DESCRIPTION
Remove opsfile for removing bosh dns features; don't really want to have that in the standard opsfile set