### PR TITLE
Remove tserver port opsfile from testing command

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -66,7 +66,6 @@ tasks:
           -o manifests/operators/logging/stderrthreshold.yml \
           -o manifests/operators/placement-options.yml \
           -o manifests/operators/sample-apps/cassandrakeyvalue.yml \
-          -o manifests/operators/tserver-rpc-bind-port.yml \
           -l manifests/operators/sample-apps/vars.yml \
           -l manifests/vars.yml \
           -l manifests/versions.yml \


### PR DESCRIPTION
accidentally forgot to do this as part of https://github.com/aegershman/yugabyte-boshrelease/pull/188