### PR TITLE
Include alternative_names of localhost and extended_key_usage in TLS certificates

### DIFF
--- a/manifests/yugabyte.yml
+++ b/manifests/yugabyte.yml
@@ -124,6 +124,13 @@ variables:
     options:
       ca: /services/tls_ca
       common_name: yugabyte
+      alternative_names:
+        - "*.master.((network)).((deployment_name)).bosh"
+        - 127.0.0.1
+        - localhost
+    extended_key_usage:
+      - client_auth
+      - server_auth
     consumes:
       alternative_name:
         from: yb-master-address-link
@@ -135,6 +142,13 @@ variables:
     options:
       ca: /services/tls_ca
       common_name: yugabyte
+      alternative_names:
+        - "*.tserver.((network)).((deployment_name)).bosh"
+        - 127.0.0.1
+        - localhost
+    extended_key_usage:
+      - client_auth
+      - server_auth
     consumes:
       alternative_name:
         from: yb-tserver-address-link

--- a/manifests/yugabyte.yml
+++ b/manifests/yugabyte.yml
@@ -125,7 +125,6 @@ variables:
       ca: /services/tls_ca
       common_name: yugabyte
       alternative_names:
-        - "*.master.((network)).((deployment_name)).bosh"
         - 127.0.0.1
         - localhost
     extended_key_usage:
@@ -143,7 +142,6 @@ variables:
       ca: /services/tls_ca
       common_name: yugabyte
       alternative_names:
-        - "*.tserver.((network)).((deployment_name)).bosh"
         - 127.0.0.1
         - localhost
     extended_key_usage:


### PR DESCRIPTION
part of https://github.com/aegershman/yugabyte-boshrelease/issues/138

scratchpad notes:
- still need to evaluate to what extent there is a problem
- experiment with adding alternative names for cert blocks; going to go a little 'over' on this and will refine
- `openssl s_client -connect 10.xxxxx.xx.x.xxxx.xxxx.y:9042`
- wait, duh, SANs can't have underscores, so if your deployment name has underscores you're screwed. Plus I'm dubious that SANs are really the issue here
- wait, wait, duh, duh, I think this is more of an issue of the fact that the SAN being generated for the bosh-dns name is using the shortened url, so the url used by client connections should be of the shortened variety; which is a little harder to determine in advance. Hm. Still testing this.