### PR TITLE
Move decorated TLS variables into opsfiles instead of main

### DIFF
--- a/manifests/operators/development/decorate-tls-certificates-with-options.yml
+++ b/manifests/operators/development/decorate-tls-certificates-with-options.yml
@@ -1,0 +1,42 @@
+# this doesn't actually do anything special, but I wanted to keep it here
+# as a mental reminder about what can be done with atlernative_names and extended_key_usage
+---
+- type: replace
+  path: /variables/name=yugabyte-server-tls-master
+  value:
+    name: yugabyte-server-tls-master
+    type: certificate
+    update_mode: converge
+    options:
+      ca: /services/tls_ca
+      common_name: yugabyte
+      alternative_names:
+        - 127.0.0.1
+        - localhost
+    extended_key_usage:
+      - client_auth
+      - server_auth
+    consumes:
+      alternative_name:
+        from: yb-master-address-link
+        properties: { wildcard: true }
+
+- type: replace
+  path: /variables/name=yugabyte-server-tls-tserver
+  value:
+    name: yugabyte-server-tls-tserver
+    type: certificate
+    update_mode: converge
+    options:
+      ca: /services/tls_ca
+      common_name: yugabyte
+      alternative_names:
+        - 127.0.0.1
+        - localhost
+    extended_key_usage:
+      - client_auth
+      - server_auth
+    consumes:
+      alternative_name:
+        from: yb-tserver-address-link
+        properties: { wildcard: true }

--- a/manifests/yugabyte.yml
+++ b/manifests/yugabyte.yml
@@ -124,12 +124,6 @@ variables:
     options:
       ca: /services/tls_ca
       common_name: yugabyte
-      alternative_names:
-        - 127.0.0.1
-        - localhost
-    extended_key_usage:
-      - client_auth
-      - server_auth
     consumes:
       alternative_name:
         from: yb-master-address-link
@@ -141,12 +135,6 @@ variables:
     options:
       ca: /services/tls_ca
       common_name: yugabyte
-      alternative_names:
-        - 127.0.0.1
-        - localhost
-    extended_key_usage:
-      - client_auth
-      - server_auth
     consumes:
       alternative_name:
         from: yb-tserver-address-link


### PR DESCRIPTION
Effectively undoes the changes in https://github.com/aegershman/yugabyte-boshrelease/pull/198

The problem was that I was using the wrong bosh-dns hostname string (long-form) instead of using the short-form dns hoststring when connecting client applications, because the certificates were generated for the short-form

But just for a mental reminder, going to move the "decorated" TLS certificates out of the main deployment manifest and into an opsfile