### PR TITLE
Bump to jdk 1.8.0_252 using bellsoft jre

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,7 +2,7 @@
 version: "2"
 
 env:
-  OPENJDK_VERSION: 1.8.0_242
+  OPENJDK_VERSION: 1.8.0_252
   PYTHON_PIP_URL: "https://files.pythonhosted.org/packages/ed/94/391a003107f6ec997c314199d03bff1c105af758ee490e3255353574487b/pip-1.5.2.tar.gz"
   PYTHON_PIP_VERSION: 1.5.2
   PYTHON_SETUPTOOLS_URL: "https://files.pythonhosted.org/packages/72/16/738ef65b2659b3a84573c51094afbfb0c263f7cd51911c3caf5e4f7b8c0b/setuptools-2.2.zip"
@@ -15,7 +15,10 @@ tasks:
   dl-openjdk:
     status: ["test -f /tmp/yugablob/openjdk-${OPENJDK_VERSION}.tar.gz"]
     cmds:
-      - curl -o /tmp/yugablob/openjdk-${OPENJDK_VERSION}.tar.gz -L "https://java-buildpack.cloudfoundry.org/openjdk/bionic/x86_64/openjdk-jre-${OPENJDK_VERSION}-bionic.tar.gz"
+      - |
+        curl -o /tmp/yugablob/jdk-index.yml https://java-buildpack.cloudfoundry.org/openjdk/bionic/x86_64/index.yml
+        OPENJDK_URL=$(grep -o "${OPENJDK_VERSION}: [^, }]*" /tmp/yugablob/jdk-index.yml | sed 's/^.*: //')
+        curl -o /tmp/yugablob/openjdk-${OPENJDK_VERSION}.tar.gz -L "${OPENJDK_URL}"
 
   dl-python:
     status:

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,24 +1,18 @@
-openjdk/openjdk-1.8.0_242.tar.gz:
-  size: 40565395
-  object_id: 66585bcc-886b-457b-57f9-a1dd0f74e8dd
-  sha: sha256:baebb2246ec503c8cae333510894d9dd6496ea72ff663f47faa85e789b58b45a
+openjdk/openjdk-1.8.0_252.tar.gz:
+  size: 40884683
+  sha: sha256:9ed792bf2dd7938968432e2876846a1dcfa95ae56f18396e64121d7450fea471
 python/Python-2.7.6.tgz:
   size: 14725931
-  object_id: e1b44754-25be-440e-4f7b-fb7435a11073
   sha: sha256:99c6860b70977befa1590029fae092ddb18db1d69ae67e8b9385b66ed104ba58
 python/pip-1.5.2.tar.gz:
   size: 1079904
-  object_id: 62820ccb-48fc-483a-6894-b2d9a7521f8a
   sha: sha256:2a8a3e08e652d3a40edbb39264bf01f8ff3c32520a79113357cca1f30533f738
 python/setuptools-2.2.zip:
   size: 840134
-  object_id: c1dfe0e2-9c19-450f-5cc3-af360884e579
   sha: sha256:e899c58f9e3b482cfac2e9ed03c6d0243ccdd90a78e8231662ae245bdd922971
 yugabyte/yb-sample-apps-1.2.1.jar:
   size: 12026031
-  object_id: a134d53e-03e2-4064-423f-7c2424cfb952
   sha: sha256:414d29070b82db7dd31584e5b29715c618d44905e2840e4a98cc7f6b3f37e42d
 yugabyte/yugabyte-2.1.6.0-linux.tar.gz:
   size: 495905466
-  object_id: d40127e3-d208-4a88-74be-ccdb0de9fbf4
   sha: sha256:dc6bf11e897c522836ff54b30d7391801a322b6b02675999960d1767ba2b7f94

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,18 +1,24 @@
 openjdk/openjdk-1.8.0_252.tar.gz:
   size: 40884683
+  object_id: 299156b8-89f1-4bfc-62e5-87fce0fc5892
   sha: sha256:9ed792bf2dd7938968432e2876846a1dcfa95ae56f18396e64121d7450fea471
 python/Python-2.7.6.tgz:
   size: 14725931
+  object_id: e3aec27a-49e4-4422-635c-f62295fb572d
   sha: sha256:99c6860b70977befa1590029fae092ddb18db1d69ae67e8b9385b66ed104ba58
 python/pip-1.5.2.tar.gz:
   size: 1079904
+  object_id: a1f12a67-9927-4940-5870-211a5989fb0e
   sha: sha256:2a8a3e08e652d3a40edbb39264bf01f8ff3c32520a79113357cca1f30533f738
 python/setuptools-2.2.zip:
   size: 840134
+  object_id: aabe6029-c33c-499b-4b60-2cd8b772c948
   sha: sha256:e899c58f9e3b482cfac2e9ed03c6d0243ccdd90a78e8231662ae245bdd922971
 yugabyte/yb-sample-apps-1.2.1.jar:
   size: 12026031
+  object_id: dcbc5b26-8b32-4678-4908-1d73951b58ac
   sha: sha256:414d29070b82db7dd31584e5b29715c618d44905e2840e4a98cc7f6b3f37e42d
 yugabyte/yugabyte-2.1.6.0-linux.tar.gz:
   size: 495905466
+  object_id: 11676a3b-76b1-4795-5a3b-37d07c43927e
   sha: sha256:dc6bf11e897c522836ff54b30d7391801a322b6b02675999960d1767ba2b7f94

--- a/packages/openjdk/packaging
+++ b/packages/openjdk/packaging
@@ -3,11 +3,14 @@
 set -eux
 
 cd ${BOSH_INSTALL_TARGET}
-mkdir jre && tar zxvf ${BOSH_COMPILE_TARGET}/openjdk/openjdk-*.tar.gz -C jre
+tar zxvf ${BOSH_COMPILE_TARGET}/openjdk/openjdk-*.tar.gz
 if [[ $? != 0 ]]; then
   echo "Cannot unpack JRE"
   exit 1
 fi
 
+#rename directory
+mv jre8* jre
+
 # latest JRE release didn't have correct permissions
-chmod -R a+r jre
+chmod -R a+rx jre


### PR DESCRIPTION
replaces https://github.com/aegershman/yugabyte-boshrelease/pull/202

As the title implies; bumps from 1.8.0_242 which uses openjdk bits to 1.8.0_252 which uses bellsoft jre. interesting stuff, right on

see: 
- https://java-buildpack.cloudfoundry.org/openjdk/bionic/x86_64/index.yml
- basically ripped from https://github.com/pivotal/credhub-release/commit/8a654c351cb62d698b41a662ce5bcc3fc3b965c9