### PR TITLE
move cqlsh references to ycqlsh

### DIFF
--- a/jobs/yb-tserver/templates/bin/post-deploy.sh
+++ b/jobs/yb-tserver/templates/bin/post-deploy.sh
@@ -8,7 +8,7 @@ echo "running post-deploy..."
 
 /var/vcap/jobs/yb-tserver/bin/ycql-rotate-default-admin-password.sh
 
-/var/vcap/packages/yugabyte/bin/cqlsh \
+/var/vcap/packages/yugabyte/bin/ycqlsh \
   --cqlshrc /var/vcap/jobs/yb-tserver/config/cqlshrc \
   --file /var/vcap/jobs/yb-tserver/config/roles.cql \
   --debug

--- a/jobs/yb-tserver/templates/bin/ycql-rotate-default-admin-password.sh.erb
+++ b/jobs/yb-tserver/templates/bin/ycql-rotate-default-admin-password.sh.erb
@@ -17,7 +17,7 @@ exit 0
 <% end %>
 
 echo "attempting current cassandra_password to see if it is already set..."
-/var/vcap/packages/yugabyte/bin/cqlsh \
+/var/vcap/packages/yugabyte/bin/ycqlsh \
     --cqlshrc /var/vcap/jobs/yb-tserver/config/cqlshrc \
     --execute "LOGIN cassandra '<%= p('ycql.cassandra_password') %>'"
 
@@ -27,14 +27,14 @@ if [[ $? == 0 ]]; then
 fi
 
 echo "attempting to update cassandra_password using cassandra_password_old..."
-/var/vcap/packages/yugabyte/bin/cqlsh \
+/var/vcap/packages/yugabyte/bin/ycqlsh \
   --cqlshrc /var/vcap/jobs/yb-tserver/config/cqlshrc \
   --password "<%= p("ycql.cassandra_password_old") %>" \
   --execute "ALTER ROLE cassandra WITH password = '<%= p('ycql.cassandra_password') %>'"
 
 if [[ $? == 0 ]]; then
   echo "cassandra_password appears to have been set using cassandra_password_old. confirming cassandra_password is in use..."
-  /var/vcap/packages/yugabyte/bin/cqlsh \
+  /var/vcap/packages/yugabyte/bin/ycqlsh \
     --cqlshrc /var/vcap/jobs/yb-tserver/config/cqlshrc \
     --execute "LOGIN cassandra '<%= p('ycql.cassandra_password') %>'"
 


### PR DESCRIPTION
as part of upstream change in https://github.com/yugabyte/yugabyte-db/issues/3935 this modifies the name reference to use ycqlsh

[the references to `.cqlshrc` remain the same](https://github.com/yugabyte/cqlsh/blob/190db9f40a14106892474691824ccae53ac3b9b7/bin/ycqlsh.py#L221)

[May need to cross-ref with python3 compatibility](https://github.com/aegershman/yugabyte-boshrelease/issues/200)