### PR TITLE
option to rm post_install.sh.completed prior to re-running post_install on pre_start

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,7 +69,6 @@ tasks:
           -l manifests/versions.yml \
           -l manifests/operators/development/vars.yml \
           --no-redact \
-          --recreate \
           --non-interactive
 
   test:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,6 +69,7 @@ tasks:
           -l manifests/versions.yml \
           -l manifests/operators/development/vars.yml \
           --no-redact \
+          --recreate \
           --non-interactive
 
   test:

--- a/jobs/yb-master/spec
+++ b/jobs/yb-master/spec
@@ -38,7 +38,7 @@ properties:
     description: |
       Remove the ".post_install.sh.completed" file marker on app startup before the "post_install.sh" script runs again
       in order to re-initialize any packaging
-    default: true
+    default: false
   rpc_bind_addresses_port:
     description: for the time being, this value is used for both "rpc_bind_addresses" and "server_broadcast_addresses"
     default: 7100

--- a/jobs/yb-master/spec
+++ b/jobs/yb-master/spec
@@ -34,6 +34,11 @@ properties:
     default: 64000
   bpm.limits.processes:
     default: 64000
+  rm_post_install_completed_on_startup:
+    description: |
+      Remove the ".post_install.sh.completed" file marker on app startup before the "post_install.sh" script runs again
+      in order to re-initialize any packaging
+    default: true
   rpc_bind_addresses_port:
     description: for the time being, this value is used for both "rpc_bind_addresses" and "server_broadcast_addresses"
     default: 7100

--- a/jobs/yb-master/templates/bin/pre_start.sh
+++ b/jobs/yb-master/templates/bin/pre_start.sh
@@ -6,6 +6,7 @@ set -eu
 chown -R vcap:vcap /var/vcap/packages/yugabyte/share/initial_sys_catalog_snapshot
 
 if [ "${RM_POST_INSTALL_COMPLETED_ON_STARTUP}" = "true" ]; then
+  echo "pre_start will be removing the .post_install.sh.completed marker before re-initializing post_install.sh"
   find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -delete
 fi
 

--- a/jobs/yb-master/templates/bin/pre_start.sh
+++ b/jobs/yb-master/templates/bin/pre_start.sh
@@ -7,7 +7,7 @@ chown -R vcap:vcap /var/vcap/packages/yugabyte/share/initial_sys_catalog_snapsho
 
 if [ "${RM_POST_INSTALL_COMPLETED_ON_STARTUP}" = "true" ]; then
   echo "pre_start will be removing the .post_install.sh.completed marker before re-initializing post_install.sh"
-  find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -delete
+  find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -print -delete
 fi
 
 /var/vcap/packages/yugabyte/bin/post_install.sh

--- a/jobs/yb-master/templates/bin/pre_start.sh
+++ b/jobs/yb-master/templates/bin/pre_start.sh
@@ -5,7 +5,6 @@ set -eu
 # TODO still necessary?
 chown -R vcap:vcap /var/vcap/packages/yugabyte/share/initial_sys_catalog_snapshot
 
-RM_POST_INSTALL_COMPLETED_ON_STARTUP=true
 if [ "${RM_POST_INSTALL_COMPLETED_ON_STARTUP}" = "true" ]; then
   find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -delete
 fi

--- a/jobs/yb-master/templates/bin/pre_start.sh
+++ b/jobs/yb-master/templates/bin/pre_start.sh
@@ -6,8 +6,8 @@ set -eu
 chown -R vcap:vcap /var/vcap/packages/yugabyte/share/initial_sys_catalog_snapshot
 
 if [ "${RM_POST_INSTALL_COMPLETED_ON_STARTUP}" = "true" ]; then
-  echo "pre_start will be removing the .post_install.sh.completed marker before re-initializing post_install.sh"
-  find -L /var/vcap/ -type f -name ".post_install.sh.completed" -print -delete
+  echo "pre_start will be removing the following .post_install.sh.completed markers before re-initializing post_install.sh..."
+  find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -print -delete
 fi
 
 /var/vcap/packages/yugabyte/bin/post_install.sh

--- a/jobs/yb-master/templates/bin/pre_start.sh
+++ b/jobs/yb-master/templates/bin/pre_start.sh
@@ -5,5 +5,10 @@ set -eu
 # TODO still necessary?
 chown -R vcap:vcap /var/vcap/packages/yugabyte/share/initial_sys_catalog_snapshot
 
+RM_POST_INSTALL_COMPLETED_ON_STARTUP=true
+if [ "${RM_POST_INSTALL_COMPLETED_ON_STARTUP}" = "true" ]; then
+  find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -delete
+fi
+
 /var/vcap/packages/yugabyte/bin/post_install.sh
 /var/vcap/jobs/yb-master/bin/cert-linker.sh

--- a/jobs/yb-master/templates/bin/pre_start.sh
+++ b/jobs/yb-master/templates/bin/pre_start.sh
@@ -7,7 +7,7 @@ chown -R vcap:vcap /var/vcap/packages/yugabyte/share/initial_sys_catalog_snapsho
 
 if [ "${RM_POST_INSTALL_COMPLETED_ON_STARTUP}" = "true" ]; then
   echo "pre_start will be removing the .post_install.sh.completed marker before re-initializing post_install.sh"
-  find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -print -delete
+  find -L /var/vcap/ -type f -name ".post_install.sh.completed" -print -delete
 fi
 
 /var/vcap/packages/yugabyte/bin/post_install.sh

--- a/jobs/yb-master/templates/config/bpm.erb.yml
+++ b/jobs/yb-master/templates/config/bpm.erb.yml
@@ -8,6 +8,7 @@ processes:
     limits:
       open_files: <%= p("bpm.limits.open_files") %>
       processes: <%= p("bpm.limits.processes") %>
-    env: {}
+    env:
+      RM_POST_INSTALL_COMPLETED_ON_STARTUP: <%= p("rm_post_install_completed_on_startup") %>
     hooks:
       pre_start: /var/vcap/jobs/yb-master/bin/pre_start

--- a/jobs/yb-tserver/spec
+++ b/jobs/yb-tserver/spec
@@ -35,6 +35,11 @@ properties:
     default: 64000
   bpm.limits.processes:
     default: 64000
+  rm_post_install_completed_on_startup:
+    description: |
+      Remove the ".post_install.sh.completed" file marker on app startup before the "post_install.sh" script runs again
+      in order to re-initialize any packaging
+    default: true
   rpc_bind_addresses_port:
     description: |
       For the time being, this value is used for both "rpc_bind_addresses" and "server_broadcast_addresses"

--- a/jobs/yb-tserver/spec
+++ b/jobs/yb-tserver/spec
@@ -39,7 +39,7 @@ properties:
     description: |
       Remove the ".post_install.sh.completed" file marker on app startup before the "post_install.sh" script runs again
       in order to re-initialize any packaging
-    default: true
+    default: false
   rpc_bind_addresses_port:
     description: |
       For the time being, this value is used for both "rpc_bind_addresses" and "server_broadcast_addresses"

--- a/jobs/yb-tserver/templates/bin/pre_start.sh
+++ b/jobs/yb-tserver/templates/bin/pre_start.sh
@@ -4,7 +4,7 @@ set -eu
 
 if [ "${RM_POST_INSTALL_COMPLETED_ON_STARTUP}" = "true" ]; then
   echo "pre_start will be removing the .post_install.sh.completed marker before re-initializing post_install.sh"
-  find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -print -delete
+  find -L /var/vcap/ -type f -name ".post_install.sh.completed" -print -delete
 fi
 
 /var/vcap/packages/yugabyte/bin/post_install.sh

--- a/jobs/yb-tserver/templates/bin/pre_start.sh
+++ b/jobs/yb-tserver/templates/bin/pre_start.sh
@@ -3,8 +3,8 @@
 set -eu
 
 if [ "${RM_POST_INSTALL_COMPLETED_ON_STARTUP}" = "true" ]; then
-  echo "pre_start will be removing the .post_install.sh.completed marker before re-initializing post_install.sh"
-  find -L /var/vcap/ -type f -name ".post_install.sh.completed" -print -delete
+  echo "pre_start will be removing the following .post_install.sh.completed markers before re-initializing post_install.sh..."
+  find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -print -delete
 fi
 
 /var/vcap/packages/yugabyte/bin/post_install.sh

--- a/jobs/yb-tserver/templates/bin/pre_start.sh
+++ b/jobs/yb-tserver/templates/bin/pre_start.sh
@@ -3,6 +3,7 @@
 set -eu
 
 if [ "${RM_POST_INSTALL_COMPLETED_ON_STARTUP}" = "true" ]; then
+  echo "pre_start will be removing the .post_install.sh.completed marker before re-initializing post_install.sh"
   find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -delete
 fi
 

--- a/jobs/yb-tserver/templates/bin/pre_start.sh
+++ b/jobs/yb-tserver/templates/bin/pre_start.sh
@@ -4,7 +4,7 @@ set -eu
 
 if [ "${RM_POST_INSTALL_COMPLETED_ON_STARTUP}" = "true" ]; then
   echo "pre_start will be removing the .post_install.sh.completed marker before re-initializing post_install.sh"
-  find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -delete
+  find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -print -delete
 fi
 
 /var/vcap/packages/yugabyte/bin/post_install.sh

--- a/jobs/yb-tserver/templates/bin/pre_start.sh
+++ b/jobs/yb-tserver/templates/bin/pre_start.sh
@@ -2,7 +2,6 @@
 
 set -eu
 
-RM_POST_INSTALL_COMPLETED_ON_STARTUP=true
 if [ "${RM_POST_INSTALL_COMPLETED_ON_STARTUP}" = "true" ]; then
   find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -delete
 fi

--- a/jobs/yb-tserver/templates/bin/pre_start.sh
+++ b/jobs/yb-tserver/templates/bin/pre_start.sh
@@ -2,5 +2,10 @@
 
 set -eu
 
+RM_POST_INSTALL_COMPLETED_ON_STARTUP=true
+if [ "${RM_POST_INSTALL_COMPLETED_ON_STARTUP}" = "true" ]; then
+  find -L /var/vcap/packages /var/vcap/data/packages -type f -name ".post_install.sh.completed" -delete
+fi
+
 /var/vcap/packages/yugabyte/bin/post_install.sh
 /var/vcap/jobs/yb-tserver/bin/cert-linker.sh

--- a/jobs/yb-tserver/templates/config/bpm.erb.yml
+++ b/jobs/yb-tserver/templates/config/bpm.erb.yml
@@ -8,6 +8,7 @@ processes:
     limits:
       open_files: <%= p("bpm.limits.open_files") %>
       processes: <%= p("bpm.limits.processes") %>
-    env: {}
+    env:
+      RM_POST_INSTALL_COMPLETED_ON_STARTUP: <%= p("rm_post_install_completed_on_startup") %>
     hooks:
       pre_start: /var/vcap/jobs/yb-tserver/bin/pre_start


### PR DESCRIPTION
part of https://github.com/aegershman/yugabyte-boshrelease/issues/217

note:

```sh
/var/vcap/packages/yugabyte/bin/yb-admin -master_addresses q-m108988n3s0.q-g107576.bosh:7100 -certs_dir_name /var/vcap/jobs/yb-master/config/certs list_tables_with_db_types
```

see:
- https://github.com/yugabyte/yugabyte-db/commit/bdec7bdc2b48301c6b097cf7f54e5bb425bdc2e3
- https://github.com/YugaByte/yugabyte-db/commit/c3a62bb1d60864254f832d489d976bdd7c422145
- https://github.com/YugaByte/yugabyte-db/commit/c3a62bb1d60864254f832d489d976bdd7c422145#diff-177b43334ff0a073592520fc7a8eaaa7R601
- https://github.com/yugabyte/yugabyte-db/commit/b68b84bfd46b6a771d828c66477a477aa0f71844
- yqlgate https://github.com/yugabyte/yugabyte-db/blob/b68b84bfd46b6a771d828c66477a477aa0f71844/src/yb/yql/pggate/pggate_flags.cc

```
conf.data_dir 
```