### PR TITLE
force node and cluster uuid overriding to match deployment names and node names

### DIFF
--- a/jobs/yb-master/templates/config/master.conf.erb
+++ b/jobs/yb-master/templates/config/master.conf.erb
@@ -9,7 +9,7 @@
 --v=<%= p("v") %>
 
 --cluster_uuid=<%= spec.deployment %>
---instance_uuid_override=<%= "#{spec.name}-#{spec.id}" %>
+--instance_uuid_override=<%= spec.id %>
 
 --master_addresses=<%= link("yb-master").instances.map { |i| "#{i.address}:#{p('rpc_bind_addresses_port')}" }.join(",") %>
 --replication_factor=<%= link("yb-master").instances.length %>

--- a/jobs/yb-master/templates/config/master.conf.erb
+++ b/jobs/yb-master/templates/config/master.conf.erb
@@ -9,7 +9,7 @@
 --v=<%= p("v") %>
 
 --cluster_uuid=<%= spec.deployment %>
---instance_uuid_override=<%= spec.id %>
+--instance_uuid_override=<%= "#{spec.name}-#{spec.id}" %>
 
 --master_addresses=<%= link("yb-master").instances.map { |i| "#{i.address}:#{p('rpc_bind_addresses_port')}" }.join(",") %>
 --replication_factor=<%= link("yb-master").instances.length %>

--- a/jobs/yb-master/templates/config/master.conf.erb
+++ b/jobs/yb-master/templates/config/master.conf.erb
@@ -8,6 +8,9 @@
 --stop_logging_if_full_disk=<%= p("stop_logging_if_full_disk") %>
 --v=<%= p("v") %>
 
+--cluster_uuid=<%= spec.deployment %>
+--instance_uuid_override=<%= spec.id %>
+
 --master_addresses=<%= link("yb-master").instances.map { |i| "#{i.address}:#{p('rpc_bind_addresses_port')}" }.join(",") %>
 --replication_factor=<%= link("yb-master").instances.length %>
 --rpc_bind_addresses=<%= spec.address %>

--- a/jobs/yb-tserver/templates/config/tserver.conf.erb
+++ b/jobs/yb-tserver/templates/config/tserver.conf.erb
@@ -8,7 +8,7 @@
 --stop_logging_if_full_disk=<%= p("stop_logging_if_full_disk") %>
 --v=<%= p("v") %>
 
---instance_uuid_override=<%= spec.id %>
+--instance_uuid_override=<%= "#{spec.name}-#{spec.id}" %>
 
 --rpc_bind_addresses=<%= spec.address %>:<%= p("rpc_bind_addresses_port") %>
 --server_broadcast_addresses=<%= spec.address %>:<%= p("rpc_bind_addresses_port") %>

--- a/jobs/yb-tserver/templates/config/tserver.conf.erb
+++ b/jobs/yb-tserver/templates/config/tserver.conf.erb
@@ -8,7 +8,7 @@
 --stop_logging_if_full_disk=<%= p("stop_logging_if_full_disk") %>
 --v=<%= p("v") %>
 
---instance_uuid_override=<%= "#{spec.name}-#{spec.id}" %>
+--instance_uuid_override=<%= spec.id %>
 
 --rpc_bind_addresses=<%= spec.address %>:<%= p("rpc_bind_addresses_port") %>
 --server_broadcast_addresses=<%= spec.address %>:<%= p("rpc_bind_addresses_port") %>

--- a/jobs/yb-tserver/templates/config/tserver.conf.erb
+++ b/jobs/yb-tserver/templates/config/tserver.conf.erb
@@ -8,6 +8,8 @@
 --stop_logging_if_full_disk=<%= p("stop_logging_if_full_disk") %>
 --v=<%= p("v") %>
 
+--instance_uuid_override=<%= spec.id %>
+
 --rpc_bind_addresses=<%= spec.address %>:<%= p("rpc_bind_addresses_port") %>
 --server_broadcast_addresses=<%= spec.address %>:<%= p("rpc_bind_addresses_port") %>
 --tserver_master_addrs=<%= m = link("yb-master"); m.instances.map { |i| "#{i.address}:#{m.p('rpc_bind_addresses_port')}" }.join(",") %>


### PR DESCRIPTION
implements: https://github.com/aegershman/yugabyte-boshrelease/issues/52

note, this wouldn't fly with an existing cluster, so it'd need to be included as part of a bump to a new universe creation... such as in the bump from 0.0.x to 0.1.x