### PR TITLE
Allow manually performing initdb in the event of upgrading a universe without ysql enabled previously

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,6 +62,7 @@ tasks:
           -o manifests/operators/gflags.yml \
           -o manifests/operators/logging/stderrthreshold.yml \
           -o manifests/operators/placement-options.yml \
+          -o manifests/operators/upgrade-0.0.x-to-0.1.x.yml \
           -o manifests/operators/sample-apps/cassandrakeyvalue.yml \
           -o manifests/operators/sample-apps/sqlinserts.yml \
           -l manifests/operators/sample-apps/vars.yml \

--- a/jobs/yb-master/spec
+++ b/jobs/yb-master/spec
@@ -34,11 +34,18 @@ properties:
     default: 64000
   bpm.limits.processes:
     default: 64000
+
   rm_post_install_completed_on_startup:
     description: |
       Remove the ".post_install.sh.completed" file marker on app startup before the "post_install.sh" script runs again
       in order to re-initialize any packaging
     default: false
+  enable_manual_ysql_init:
+    description: |
+      Manually perform a postgres initdb to initialize system tables. This is valuable when enabling ysql on a universe
+      which didn't previously have ysql enabled when the universe was created.
+    default: false
+
   rpc_bind_addresses_port:
     description: for the time being, this value is used for both "rpc_bind_addresses" and "server_broadcast_addresses"
     default: 7100

--- a/jobs/yb-master/templates/bin/pre_start.sh
+++ b/jobs/yb-master/templates/bin/pre_start.sh
@@ -13,7 +13,6 @@ fi
 /var/vcap/packages/yugabyte/bin/post_install.sh
 /var/vcap/jobs/yb-master/bin/cert-linker.sh
 
-ENABLE_MANUAL_YSQL_INIT=true
 if [ "${ENABLE_MANUAL_YSQL_INIT}" = "true" ]; then
   echo "pre_start is now performing a manual initdb for ysql"
   YB_ENABLED_IN_POSTGRES=1

--- a/jobs/yb-master/templates/bin/pre_start.sh
+++ b/jobs/yb-master/templates/bin/pre_start.sh
@@ -12,3 +12,11 @@ fi
 
 /var/vcap/packages/yugabyte/bin/post_install.sh
 /var/vcap/jobs/yb-master/bin/cert-linker.sh
+
+ENABLE_MANUAL_YSQL_INIT=true
+if [ "${ENABLE_MANUAL_YSQL_INIT}" = "true" ]; then
+  echo "pre_start is now performing a manual initdb for ysql"
+  YB_ENABLED_IN_POSTGRES=1
+  FLAGS_pggate_master_addresses=<%= link("yb-master").instances.map { |i| "#{i.address}:#{p('rpc_bind_addresses_port')}" }.join(",") %>
+  su - vcap -c '/var/vcap/packages/yugabyte/postgres/bin/initdb -D /var/vcap/data/yb-master/tmp/pg_data_tmp -U postgres'
+fi

--- a/jobs/yb-master/templates/config/bpm.erb.yml
+++ b/jobs/yb-master/templates/config/bpm.erb.yml
@@ -9,6 +9,7 @@ processes:
       open_files: <%= p("bpm.limits.open_files") %>
       processes: <%= p("bpm.limits.processes") %>
     env:
+      ENABLE_MANUAL_YSQL_INIT: <%= p("enable_manual_ysql_init") %>
       RM_POST_INSTALL_COMPLETED_ON_STARTUP: <%= p("rm_post_install_completed_on_startup") %>
     hooks:
       pre_start: /var/vcap/jobs/yb-master/bin/pre_start

--- a/jobs/yb-tserver/spec
+++ b/jobs/yb-tserver/spec
@@ -35,11 +35,18 @@ properties:
     default: 64000
   bpm.limits.processes:
     default: 64000
+
   rm_post_install_completed_on_startup:
     description: |
       Remove the ".post_install.sh.completed" file marker on app startup before the "post_install.sh" script runs again
       in order to re-initialize any packaging
     default: false
+  enable_manual_ysql_init:
+    description: |
+      Manually perform a postgres initdb to initialize system tables. This is valuable when enabling ysql on a universe
+      which didn't previously have ysql enabled when the universe was created.
+    default: false
+
   rpc_bind_addresses_port:
     description: |
       For the time being, this value is used for both "rpc_bind_addresses" and "server_broadcast_addresses"

--- a/jobs/yb-tserver/templates/bin/pre_start.sh
+++ b/jobs/yb-tserver/templates/bin/pre_start.sh
@@ -9,3 +9,11 @@ fi
 
 /var/vcap/packages/yugabyte/bin/post_install.sh
 /var/vcap/jobs/yb-tserver/bin/cert-linker.sh
+
+ENABLE_MANUAL_YSQL_INIT=true
+if [ "${ENABLE_MANUAL_YSQL_INIT}" = "true" ]; then
+  echo "pre_start is now performing a manual initdb for ysql"
+  YB_ENABLED_IN_POSTGRES=1
+  FLAGS_pggate_master_addresses=<%= link("yb-master").instances.map { |i| "#{i.address}:#{p('rpc_bind_addresses_port')}" }.join(",") %>
+  su - vcap -c '/var/vcap/packages/yugabyte/postgres/bin/initdb -D /var/vcap/data/yb-tserver/tmp/pg_data_tmp -U postgres'
+fi

--- a/jobs/yb-tserver/templates/bin/pre_start.sh
+++ b/jobs/yb-tserver/templates/bin/pre_start.sh
@@ -10,7 +10,6 @@ fi
 /var/vcap/packages/yugabyte/bin/post_install.sh
 /var/vcap/jobs/yb-tserver/bin/cert-linker.sh
 
-ENABLE_MANUAL_YSQL_INIT=true
 if [ "${ENABLE_MANUAL_YSQL_INIT}" = "true" ]; then
   echo "pre_start is now performing a manual initdb for ysql"
   YB_ENABLED_IN_POSTGRES=1

--- a/jobs/yb-tserver/templates/config/bpm.erb.yml
+++ b/jobs/yb-tserver/templates/config/bpm.erb.yml
@@ -9,6 +9,7 @@ processes:
       open_files: <%= p("bpm.limits.open_files") %>
       processes: <%= p("bpm.limits.processes") %>
     env:
+      ENABLE_MANUAL_YSQL_INIT: <%= p("enable_manual_ysql_init") %>
       RM_POST_INSTALL_COMPLETED_ON_STARTUP: <%= p("rm_post_install_completed_on_startup") %>
     hooks:
       pre_start: /var/vcap/jobs/yb-tserver/bin/pre_start

--- a/manifests/operators/upgrade-0.0.x-to-0.1.x.yml
+++ b/manifests/operators/upgrade-0.0.x-to-0.1.x.yml
@@ -1,0 +1,18 @@
+# Use this opsfile when upgrading an existing universe to 0.0.x to 0.1.x which has ysql enabled
+# by default. Remove this opsfile as soon as you have the upgrade finished.
+---
+- type: replace
+  path: /instance_groups/name=master/jobs/name=yb-master/properties?/rm_post_install_completed_on_startup?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=tserver/jobs/name=yb-tserver/properties?/rm_post_install_completed_on_startup?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=master/jobs/name=yb-master/properties?/enable_manual_ysql_init?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=tserver/jobs/name=yb-tserver/properties?/enable_manual_ysql_init?
+  value: true


### PR DESCRIPTION
as the title implies. part of https://github.com/aegershman/yugabyte-boshrelease/issues/217