### PR TITLE
ysql must be on now

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a [BOSH](http://bosh.io/) release for [YugabyteDB](https://github.com/yugabyte/yugabyte-db).
 
+## ysql and you
+
+You should be aware that as of `0.1.x`, `ysql` (`postgres` API compatibility) is on by default. It currently cannot be turned off. This is because it simplifies operationalization and testing to be able to make these assumptions. If being able to turn off `ysql` is an issue for you, please let us know in a comment so that we can take it into consideration. It's not that it's impossible, we're just taking certain opinionated defaults.
+
 ## server-to-server tls
 
 TLS is currently under development. For the time being it's on by default, and `allow_insecure_connections: false` between nodes by default. You can opt-out using an operator file.

--- a/jobs/yb-master/spec
+++ b/jobs/yb-master/spec
@@ -82,11 +82,6 @@ properties:
   tls.node.key:
     description: "TLS key for this node"
 
-  enable_ysql:
-    description: |
-      Enables the YSQL API when value is true. Replaces the deprecated --start_pgsql_proxy option.
-    default: true
-
   gflags:
     description: extra "--key=value" properties to pass to the conf file
     example:

--- a/jobs/yb-master/templates/bin/pre_start.sh
+++ b/jobs/yb-master/templates/bin/pre_start.sh
@@ -17,5 +17,12 @@ if [ "${ENABLE_MANUAL_YSQL_INIT}" = "true" ]; then
   echo "pre_start is now performing a manual initdb for ysql"
   YB_ENABLED_IN_POSTGRES=1
   FLAGS_pggate_master_addresses=<%= link("yb-master").instances.map { |i| "#{i.address}:#{p('rpc_bind_addresses_port')}" }.join(",") %>
+
+  if [ -d "/var/vcap/data/yb-master/tmp/pg_data_tmp" ]; then
+    echo "/var/vcap/data/yb-master/tmp/pg_data_tmp appears to exist, will remove before re-initializing..."
+    echo "WARNING: THIS MEANS YOU SHOULD PROBABLY REMOVE ANY UPGRADE OPSFILES"
+    rm -rf /var/vcap/data/yb-master/tmp/pg_data_tmp
+  fi
+
   su - vcap -c '/var/vcap/packages/yugabyte/postgres/bin/initdb -D /var/vcap/data/yb-master/tmp/pg_data_tmp -U postgres'
 fi

--- a/jobs/yb-master/templates/bin/pre_start.sh
+++ b/jobs/yb-master/templates/bin/pre_start.sh
@@ -18,11 +18,12 @@ if [ "${ENABLE_MANUAL_YSQL_INIT}" = "true" ]; then
   YB_ENABLED_IN_POSTGRES=1
   FLAGS_pggate_master_addresses=<%= link("yb-master").instances.map { |i| "#{i.address}:#{p('rpc_bind_addresses_port')}" }.join(",") %>
 
-  if [ -d "/var/vcap/data/yb-master/tmp/pg_data_tmp" ]; then
-    echo "/var/vcap/data/yb-master/tmp/pg_data_tmp appears to exist, will remove before re-initializing..."
+  if [ ! -d "/var/vcap/data/yb-master/tmp/pg_data_tmp" ]; then
+    echo "/var/vcap/data/yb-master/tmp/pg_data_tmp does not appear to exist, now manually initializing with initdb..."
+    su - vcap -c '/var/vcap/packages/yugabyte/postgres/bin/initdb -D /var/vcap/data/yb-master/tmp/pg_data_tmp -U postgres'
+  else
+    echo "/var/vcap/data/yb-master/tmp/pg_data_tmp appears to already exist, not removing anything..."
     echo "WARNING: THIS MEANS YOU SHOULD PROBABLY REMOVE ANY UPGRADE OPSFILES"
-    rm -rf /var/vcap/data/yb-master/tmp/pg_data_tmp
   fi
 
-  su - vcap -c '/var/vcap/packages/yugabyte/postgres/bin/initdb -D /var/vcap/data/yb-master/tmp/pg_data_tmp -U postgres'
 fi

--- a/jobs/yb-master/templates/config/master.conf.erb
+++ b/jobs/yb-master/templates/config/master.conf.erb
@@ -15,11 +15,9 @@
 --webserver_interface=<%= spec.address %>
 --webserver_port=<%= p("webserver_port") %>
 
---enable_ysql=<%= p("enable_ysql") %>
-<% if p("enable_ysql") -%>
+--enable_ysql=true
 --initial_sys_catalog_snapshot_path=/var/vcap/packages/yugabyte/share/initial_sys_catalog_snapshot
---master_auto_run_initdb=<%= p("enable_ysql") %>
-<% end -%>
+--master_auto_run_initdb=true
 
 --default_memory_limit_to_ram_ratio=<%= p("default_memory_limit_to_ram_ratio") %>
 

--- a/jobs/yb-tserver/spec
+++ b/jobs/yb-tserver/spec
@@ -94,10 +94,6 @@ properties:
   tls.node.key:
     description: "TLS key for this node"
 
-  enable_ysql:
-    description: |
-      Enables the YSQL API when value is true. Replaces the deprecated --start_pgsql_proxy option.
-    default: true
   ysql_hba_conf:
     description: |
       Specifies a comma-separated list of PostgreSQL client authentication settings that is written to the ysql_hba.conf file.

--- a/jobs/yb-tserver/templates/bin/pre_start.sh
+++ b/jobs/yb-tserver/templates/bin/pre_start.sh
@@ -14,5 +14,12 @@ if [ "${ENABLE_MANUAL_YSQL_INIT}" = "true" ]; then
   echo "pre_start is now performing a manual initdb for ysql"
   YB_ENABLED_IN_POSTGRES=1
   FLAGS_pggate_master_addresses=<%= link("yb-master").instances.map { |i| "#{i.address}:#{p('rpc_bind_addresses_port')}" }.join(",") %>
+
+  if [ -d "/var/vcap/data/yb-tserver/tmp/pg_data_tmp" ]; then
+    echo "/var/vcap/data/yb-tserver/tmp/pg_data_tmp appears to exist, will remove before re-initializing..."
+    echo "WARNING: THIS MEANS YOU SHOULD PROBABLY REMOVE ANY UPGRADE OPSFILES"
+    rm -rf /var/vcap/data/yb-tserver/tmp/pg_data_tmp
+  fi
+
   su - vcap -c '/var/vcap/packages/yugabyte/postgres/bin/initdb -D /var/vcap/data/yb-tserver/tmp/pg_data_tmp -U postgres'
 fi

--- a/jobs/yb-tserver/templates/bin/pre_start.sh
+++ b/jobs/yb-tserver/templates/bin/pre_start.sh
@@ -15,11 +15,12 @@ if [ "${ENABLE_MANUAL_YSQL_INIT}" = "true" ]; then
   YB_ENABLED_IN_POSTGRES=1
   FLAGS_pggate_master_addresses=<%= link("yb-master").instances.map { |i| "#{i.address}:#{p('rpc_bind_addresses_port')}" }.join(",") %>
 
-  if [ -d "/var/vcap/data/yb-tserver/tmp/pg_data_tmp" ]; then
-    echo "/var/vcap/data/yb-tserver/tmp/pg_data_tmp appears to exist, will remove before re-initializing..."
+  if [ ! -d "/var/vcap/data/yb-tserver/tmp/pg_data_tmp" ]; then
+    echo "/var/vcap/data/yb-tserver/tmp/pg_data_tmp does not appear to exist, now manually initializing with initdb..."
+    su - vcap -c '/var/vcap/packages/yugabyte/postgres/bin/initdb -D /var/vcap/data/yb-tserver/tmp/pg_data_tmp -U postgres'
+  else
+    echo "/var/vcap/data/yb-tserver/tmp/pg_data_tmp appears to already exist, not removing anything..."
     echo "WARNING: THIS MEANS YOU SHOULD PROBABLY REMOVE ANY UPGRADE OPSFILES"
-    rm -rf /var/vcap/data/yb-tserver/tmp/pg_data_tmp
   fi
 
-  su - vcap -c '/var/vcap/packages/yugabyte/postgres/bin/initdb -D /var/vcap/data/yb-tserver/tmp/pg_data_tmp -U postgres'
 fi

--- a/jobs/yb-tserver/templates/config/tserver.conf.erb
+++ b/jobs/yb-tserver/templates/config/tserver.conf.erb
@@ -14,7 +14,7 @@
 --webserver_interface=<%= spec.address %>
 --webserver_port=<%= p("webserver_port") %>
 
---enable_ysql=<%= p("enable_ysql") %>
+--enable_ysql=true
 --ysql_hba_conf=<%= p("ysql_hba_conf") %>
 --ysql_max_connections=<%= p("ysql_max_connections") %>
 --ysql_default_transaction_isolation='<%= p("ysql_default_transaction_isolation") %>'

--- a/manifests/operators/enable_ysql.yml
+++ b/manifests/operators/enable_ysql.yml
@@ -1,8 +1,0 @@
----
-- type: replace
-  path: /instance_groups/name=master/jobs/name=yb-master/properties?/enable_ysql?
-  value: ((master_enable_ysql))
-
-- type: replace
-  path: /instance_groups/name=tserver/jobs/name=yb-tserver/properties?/enable_ysql?
-  value: ((tserver_enable_ysql))


### PR DESCRIPTION
congratulations! ysql must be on now.

partially continues https://github.com/aegershman/yugabyte-boshrelease/pull/223 by virtue of having any existing /tmp/xyz initialization directories be removed if the opsfiles are still in place during upgrade