### PR TITLE
ysql basic auth for default yugabyte superuser

### DIFF
--- a/jobs/yb-tserver/spec
+++ b/jobs/yb-tserver/spec
@@ -152,6 +152,16 @@ properties:
       NOTE: On a per-table basis, the CREATE TABLE ...SPLIT INTO clause can be used to override the ysql_num_shards_per_tserver value.
       IMPORTANT: This value must match on all yb-master and yb-tserver configurations of a YugabyteDB cluster.
     default: 8
+  ysql.databases.superusers:
+    description: |
+      Until we get to putting a more fine-grained RBAC model in place
+      we'll just assume every created user is a superuser
+    example: |
+      ysql:
+        databases:
+          superusers:
+            - name: beepbeep
+              password: honkhonk
 
   durable_wal_write:
     description: |

--- a/jobs/yb-tserver/spec
+++ b/jobs/yb-tserver/spec
@@ -15,7 +15,10 @@ templates:
   config/certs/node.crt.erb: config/certs/node.crt
   config/certs/node.key.erb: config/certs/node.key
   config/cqlshrc.erb: config/cqlshrc
+  config/pgpass.erb: config/pgpass
+  config/psqlrc.erb: config/psqlrc
   config/roles.cql.erb: config/roles.cql
+  config/roles.sql.erb: config/roles.sql
   config/tserver.conf.erb: config/tserver.conf
 
 packages:

--- a/jobs/yb-tserver/spec
+++ b/jobs/yb-tserver/spec
@@ -94,12 +94,22 @@ properties:
   tls.node.key:
     description: "TLS key for this node"
 
+  ysql_enable_auth:
+    description: |
+      The default YSQL user "yugabyte" now has password "yugabyte" by default.
+      However, the password is only required if auth is explicitly enabled (e.g. using the "ysql_enable_auth" flag), since otherwise we use trust all.
+      see: https://docs.yugabyte.com/latest/reference/configuration/yb-tserver/#ysql-enable-auth
+      see: https://github.com/yugabyte/yugabyte-db/blob/f3ed9f1876cf02c063f5f8d053a7f02b284652cc/src/yb/yql/pgwrapper/pg_wrapper.cc#L51
+      see: https://github.com/yugabyte/yugabyte-db/commit/6f37b9e02336a197b259ffe4e867850de8763778
+    default: true
   ysql_hba_conf:
     description: |
       Specifies a comma-separated list of PostgreSQL client authentication settings that is written to the ysql_hba.conf file.
       For details on using --ysql_hba_conf to specify client authentication, see fine-grained authentication.
       See: https://docs.yugabyte.com/latest/secure/authentication/client-authentication
-    default: "host all all 0.0.0.0/0 trust,host all all ::0/0 trust"
+    default: ""
+    example:
+      ysql_hba_conf: "host all all 0.0.0.0/0 trust,host all all ::0/0 trust"
   ysql_max_connections:
     description: Specifies the maximum number of concurrent YSQL connections.
     default: 300

--- a/jobs/yb-tserver/spec
+++ b/jobs/yb-tserver/spec
@@ -107,9 +107,7 @@ properties:
       Specifies a comma-separated list of PostgreSQL client authentication settings that is written to the ysql_hba.conf file.
       For details on using --ysql_hba_conf to specify client authentication, see fine-grained authentication.
       See: https://docs.yugabyte.com/latest/secure/authentication/client-authentication
-    default: ""
-    example:
-      ysql_hba_conf: "host all all 0.0.0.0/0 trust,host all all ::0/0 trust"
+    default: "host all all 0.0.0.0/0 trust,host all all ::0/0 trust"
   ysql_max_connections:
     description: Specifies the maximum number of concurrent YSQL connections.
     default: 300

--- a/jobs/yb-tserver/spec
+++ b/jobs/yb-tserver/spec
@@ -15,8 +15,6 @@ templates:
   config/certs/node.crt.erb: config/certs/node.crt
   config/certs/node.key.erb: config/certs/node.key
   config/cqlshrc.erb: config/cqlshrc
-  config/pgpass.erb: config/pgpass
-  config/psqlrc.erb: config/psqlrc
   config/roles.cql.erb: config/roles.cql
   config/roles.sql.erb: config/roles.sql
   config/tserver.conf.erb: config/tserver.conf

--- a/jobs/yb-tserver/templates/bin/post-deploy.sh
+++ b/jobs/yb-tserver/templates/bin/post-deploy.sh
@@ -16,15 +16,15 @@ echo "running post-deploy ycqlsh setup..."
   --debug
 
 echo "running post-deploy for ysqlsh setup..."
-PGDATABASE=yugabyte
-PGHOST=<%= spec.address %>
-PGPASSWORD=yugabyte
-PGPORT=<%= p("pgsql_proxy_bind_port") %>
-PGSSLCERT='/var/vcap/jobs/yb-tserver/config/certs/node.crt'
-PGSSLKEY='/var/vcap/jobs/yb-tserver/config/certs/node.key'
-PGSSLMODE='prefer'
-PGSSLROOTCERT='/var/vcap/jobs/yb-tserver/config/certs/ca.crt'
-PGUSER=yugabyte
+export PGDATABASE=yugabyte
+export PGHOST=<%= spec.address %>
+export PGPASSWORD=yugabyte
+export PGPORT=<%= p("pgsql_proxy_bind_port") %>
+export PGSSLCERT='/var/vcap/jobs/yb-tserver/config/certs/node.crt'
+export PGSSLKEY='/var/vcap/jobs/yb-tserver/config/certs/node.key'
+export PGSSLMODE='prefer'
+export PGSSLROOTCERT='/var/vcap/jobs/yb-tserver/config/certs/ca.crt'
+export PGUSER=yugabyte
 /var/vcap/packages/yugabyte/bin/ysqlsh \
   --echo-all \
   --no-psqlrc \

--- a/jobs/yb-tserver/templates/bin/post-deploy.sh
+++ b/jobs/yb-tserver/templates/bin/post-deploy.sh
@@ -12,3 +12,9 @@ echo "running post-deploy..."
   --cqlshrc /var/vcap/jobs/yb-tserver/config/cqlshrc \
   --file /var/vcap/jobs/yb-tserver/config/roles.cql \
   --debug
+
+PSQLRC=/var/vcap/jobs/yb-tserver/config/psqlrc
+PGPASSFILE=/var/vcap/jobs/yb-tserver/config/pgpass
+/var/vcap/packages/yugabyte/bin/ysqlsh \
+  --list
+  # --file=/var/vcap/jobs/yb-tserver/config/roles.sql

--- a/jobs/yb-tserver/templates/bin/post-deploy.sh
+++ b/jobs/yb-tserver/templates/bin/post-deploy.sh
@@ -2,19 +2,32 @@
 
 set -eu
 
-source /var/vcap/packages/python*/bosh/runtime.env
-
 echo "running post-deploy..."
 
+source /var/vcap/packages/python*/bosh/runtime.env
+
+echo "running post-deploy ycql rotate admin password check..."
 /var/vcap/jobs/yb-tserver/bin/ycql-rotate-default-admin-password.sh
 
+echo "running post-deploy ycqlsh setup..."
 /var/vcap/packages/yugabyte/bin/ycqlsh \
   --cqlshrc /var/vcap/jobs/yb-tserver/config/cqlshrc \
   --file /var/vcap/jobs/yb-tserver/config/roles.cql \
   --debug
 
-PSQLRC=/var/vcap/jobs/yb-tserver/config/psqlrc
-PGPASSFILE=/var/vcap/jobs/yb-tserver/config/pgpass
+echo "running post-deploy for ysqlsh setup..."
+PGDATABASE=yugabyte
+PGHOST=<%= spec.address %>
+PGPASSWORD=yugabyte
+PGPORT=<%= p("pgsql_proxy_bind_port") %>
+PGSSLCERT='/var/vcap/jobs/yb-tserver/config/certs/node.crt'
+PGSSLKEY='/var/vcap/jobs/yb-tserver/config/certs/node.key'
+PGSSLMODE='prefer'
+PGSSLROOTCERT='/var/vcap/jobs/yb-tserver/config/certs/ca.crt'
+PGUSER=yugabyte
 /var/vcap/packages/yugabyte/bin/ysqlsh \
-  --list
-  # --file=/var/vcap/jobs/yb-tserver/config/roles.sql
+  --echo-all \
+  --no-psqlrc \
+  --file=/var/vcap/jobs/yb-tserver/config/roles.sql
+
+echo "post-deploy run complete..."

--- a/jobs/yb-tserver/templates/config/psqlrc.erb
+++ b/jobs/yb-tserver/templates/config/psqlrc.erb
@@ -1,0 +1,1 @@
+<%= spec.address %>:<%= p("pgsql_proxy_bind_port") %>:yugabyte:yugabyte:yugabyte

--- a/jobs/yb-tserver/templates/config/psqlrc.erb
+++ b/jobs/yb-tserver/templates/config/psqlrc.erb
@@ -1,1 +1,0 @@
-<%= spec.address %>:<%= p("pgsql_proxy_bind_port") %>:yugabyte:yugabyte:yugabyte

--- a/jobs/yb-tserver/templates/config/roles.sql.erb
+++ b/jobs/yb-tserver/templates/config/roles.sql.erb
@@ -1,0 +1,1 @@
+SELECT * from pg_roles;

--- a/jobs/yb-tserver/templates/config/roles.sql.erb
+++ b/jobs/yb-tserver/templates/config/roles.sql.erb
@@ -1,1 +1,16 @@
-SELECT * from pg_roles;
+<% p("ycql.databases.superusers", []).each do |role| %>
+
+DO
+$body$
+BEGIN
+  IF NOT EXISTS (SELECT FROM system_auth.roles WHERE rolname = '<%= role["name"] %>') THEN
+    CREATE ROLE "<%= role["name"] %>" WITH LOGIN;
+  END IF;
+END
+$body$;
+
+ALTER ROLE "<%= role["name"] %>"
+  WITH LOGIN SUPERUSER PASSWORD '<%= role["password"] %>'
+  ;
+
+<% end %>

--- a/jobs/yb-tserver/templates/config/tserver.conf.erb
+++ b/jobs/yb-tserver/templates/config/tserver.conf.erb
@@ -20,9 +20,9 @@
 --ysql_log_statement='<%= p("ysql_log_statement") %>'
 --ysql_log_min_messages=<%= p("ysql_log_min_messages") %>
 --ysql_enable_auth=<%= p("ysql_enable_auth") %>
-<% if p("ysql_hba_conf") -%>
+<% if p("ysql_hba_conf") != "" %>
 --ysql_hba_conf=<%= p("ysql_hba_conf") %>
-<% end -%>
+<% end %>
 
 --cql_proxy_bind_address=<%= spec.address %>:<%= p("cql_proxy_bind_port") %>
 --pgsql_proxy_bind_address=<%= spec.address %>:<%= p("pgsql_proxy_bind_port") %>

--- a/jobs/yb-tserver/templates/config/tserver.conf.erb
+++ b/jobs/yb-tserver/templates/config/tserver.conf.erb
@@ -20,6 +20,7 @@
 --ysql_default_transaction_isolation='<%= p("ysql_default_transaction_isolation") %>'
 --ysql_log_statement='<%= p("ysql_log_statement") %>'
 --ysql_log_min_messages=<%= p("ysql_log_min_messages") %>
+--ysql_enable_auth=true
 
 --cql_proxy_bind_address=<%= spec.address %>:<%= p("cql_proxy_bind_port") %>
 --pgsql_proxy_bind_address=<%= spec.address %>:<%= p("pgsql_proxy_bind_port") %>

--- a/jobs/yb-tserver/templates/config/tserver.conf.erb
+++ b/jobs/yb-tserver/templates/config/tserver.conf.erb
@@ -15,12 +15,14 @@
 --webserver_port=<%= p("webserver_port") %>
 
 --enable_ysql=true
---ysql_hba_conf=<%= p("ysql_hba_conf") %>
 --ysql_max_connections=<%= p("ysql_max_connections") %>
 --ysql_default_transaction_isolation='<%= p("ysql_default_transaction_isolation") %>'
 --ysql_log_statement='<%= p("ysql_log_statement") %>'
 --ysql_log_min_messages=<%= p("ysql_log_min_messages") %>
---ysql_enable_auth=true
+--ysql_enable_auth=<%= p("ysql_enable_auth") %>
+<% if p("ysql_hba_conf") -%>
+--ysql_hba_conf=<%= p("ysql_hba_conf") %>
+<% end -%>
 
 --cql_proxy_bind_address=<%= spec.address %>:<%= p("cql_proxy_bind_port") %>
 --pgsql_proxy_bind_address=<%= spec.address %>:<%= p("pgsql_proxy_bind_port") %>

--- a/manifests/operators/sample-apps/sqlinserts.yml
+++ b/manifests/operators/sample-apps/sqlinserts.yml
@@ -17,6 +17,8 @@
           workload:
             type: SqlInserts
             args:
+              username: yugabyte
+              password: yugabyte
               num_unique_keys: 1000000000
               num_reads: -1
               num_writes: -1

--- a/manifests/operators/sample-apps/sqlinserts.yml
+++ b/manifests/operators/sample-apps/sqlinserts.yml
@@ -17,8 +17,8 @@
           workload:
             type: SqlInserts
             args:
-              username: yugabyte
-              password: yugabyte
+              username: admin
+              password: ((ycql_superuser_admin_password))
               num_unique_keys: 1000000000
               num_reads: -1
               num_writes: -1

--- a/manifests/yugabyte.yml
+++ b/manifests/yugabyte.yml
@@ -80,6 +80,13 @@ instance_groups:
               superusers:
                 - name: admin
                   password: ((ycql_superuser_admin_password))
+          ysql:
+            databases:
+              superusers:
+                - name: admin
+                  # TODO note: at least for the moment,
+                  # we're reusing the same password here for convenience
+                  password: ((ycql_superuser_admin_password))
           tls:
             node:
               ca: ((yugabyte-server-tls-tserver.ca))


### PR DESCRIPTION
see also:
- https://github.com/aegershman/yugabyte-boshrelease/issues/34
- https://github.com/aegershman/yugabyte-boshrelease/issues/36

and see also:
- https://github.com/cloudfoundry-community/postgres-boshrelease
- https://github.com/cloudfoundry/postgres-release
- https://github.com/yugabyte/yugabyte-db/blob/ceb6ce6a6571cd501c45fa9988d160187720649f/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgConfiguration.java
- https://docs.yugabyte.com/latest/reference/configuration/yb-tserver/#ysql-enable-auth

psql options:
- https://github.com/yugabyte/yugabyte-db/tree/master/src/postgres/src/bin/psql
- https://www.postgresql.org/docs/current/app-psql.html
- https://github.com/cloudfoundry/postgres-release/blob/develop/jobs/postgres/templates/roles.sql.erb
- https://github.com/cloudfoundry/postgres-release/blob/develop/templates/operations/set_properties.yml
- https://github.com/cloudfoundry/postgres-release/blob/develop/jobs/postgres/spec
- https://github.com/scottillogical/postgres-boshrelease/blob/5c8fd69fe1843309bcf108d0a6177e0125208376/jobs/postgres/templates/helpers/ctl_setup.sh
- https://www.postgresql.org/docs/9.3/app-createuser.html
- https://stackoverflow.com/questions/6523019/postgresql-scripting-psql-execution-with-password
- https://newfivefour.com/postgresql-pgpass-password-file.html
- https://thoughtbot.com/blog/an-explained-psqlrc
- https://github.com/cloudfoundry-community/postgres-boshrelease/blob/master/jobs/smoke-tests/templates/bin/run
- https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-PASSFILE
- https://www.postgresql.org/docs/current/libpq-pgpass.html
- https://www.postgresql.org/docs/current/libpq-envars.html
- https://stackoverflow.com/questions/16786011/postgresql-pgpass-not-working
- https://alvinalexander.com/blog/post/postgresql/log-in-postgresql-database/
- https://github.com/yugabyte/yugabyte-db/commit/52b36db645b458924f9ac0883f4e2c293a862612