### PR TITLE
ysqlsh was failing in certain situations, was using wrong table

### DIFF
--- a/jobs/yb-tserver/templates/bin/post-deploy.sh
+++ b/jobs/yb-tserver/templates/bin/post-deploy.sh
@@ -25,10 +25,7 @@ export PGSSLKEY='/var/vcap/jobs/yb-tserver/config/certs/node.key'
 export PGSSLMODE='prefer'
 export PGSSLROOTCERT='/var/vcap/jobs/yb-tserver/config/certs/ca.crt'
 export PGUSER=yugabyte
-# TODO I won't lie, I'm not 100% confident in --single-transaction
-# or whether ON_ERROR_STOP should actually go in psqlrc
 /var/vcap/packages/yugabyte/bin/ysqlsh \
-  --echo-all \
   --no-psqlrc \
   --set=ON_ERROR_STOP=1 \
   --single-transaction \

--- a/jobs/yb-tserver/templates/bin/post-deploy.sh
+++ b/jobs/yb-tserver/templates/bin/post-deploy.sh
@@ -25,9 +25,13 @@ export PGSSLKEY='/var/vcap/jobs/yb-tserver/config/certs/node.key'
 export PGSSLMODE='prefer'
 export PGSSLROOTCERT='/var/vcap/jobs/yb-tserver/config/certs/ca.crt'
 export PGUSER=yugabyte
+# TODO I won't lie, I'm not 100% confident in --single-transaction
+# or whether ON_ERROR_STOP should actually go in psqlrc
 /var/vcap/packages/yugabyte/bin/ysqlsh \
   --echo-all \
   --no-psqlrc \
+  --set=ON_ERROR_STOP=1 \
+  --single-transaction \
   --file=/var/vcap/jobs/yb-tserver/config/roles.sql
 
 echo "post-deploy run complete..."

--- a/jobs/yb-tserver/templates/config/roles.sql.erb
+++ b/jobs/yb-tserver/templates/config/roles.sql.erb
@@ -3,7 +3,7 @@
 DO
 $body$
 BEGIN
-  IF NOT EXISTS (SELECT FROM system_auth.roles WHERE rolname = '<%= role["name"] %>') THEN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '<%= role["name"] %>') THEN
     CREATE ROLE "<%= role["name"] %>" WITH LOGIN;
   END IF;
 END

--- a/manifests/yugabyte.yml
+++ b/manifests/yugabyte.yml
@@ -83,9 +83,10 @@ instance_groups:
           ysql:
             databases:
               superusers:
+                # TODO note: at least for the moment we're reusing the
+                # same username/password in ysql as we are for ycql for convenience.
+                # The reason we use ycql in the variable name is because... well, it came first.
                 - name: admin
-                  # TODO note: at least for the moment,
-                  # we're reusing the same password here for convenience
                   password: ((ycql_superuser_admin_password))
           tls:
             node:


### PR DESCRIPTION
see also:
- https://docs.yugabyte.com/latest/secure/authorization/rbac-model/#roles
- https://docs.yugabyte.com/latest/api/ysql/commands/dcl_create_role/
- https://docs.yugabyte.com/latest/secure/authorization/create-roles/
- https://docs.yugabyte.com/latest/secure/authentication/ysql-authentication/#create-a-user-with-superuser-status
- https://github.com/aegershman/yugabyte-boshrelease/issues/36
- https://github.com/aegershman/yugabyte-boshrelease/issues/34

remove --echo-all (outputting passwords into logs, not ideal)

