### PR TITLE
remove following symlink path on post-install to bin dir instead of only distribution directory

### DIFF
--- a/src/yugabyte-additional/post_install.sh
+++ b/src/yugabyte-additional/post_install.sh
@@ -35,7 +35,7 @@ patch_binary() {
 
 # Use pwd -P to resolve any symlinks on the path. Otherwise the find command at the bottom of this
 # script will not actually find any files.
-bin_dir=$(cd "${BASH_SOURCE%/*}" && pwd -P)
+bin_dir=$(cd "${BASH_SOURCE%/*}" && pwd)
 distribution_dir=$(cd "$bin_dir/.." && pwd -P)
 
 lib_dir="$distribution_dir/lib"


### PR DESCRIPTION
continuation of https://github.com/aegershman/yugabyte-boshrelease/pull/239

When the distribution directory paths are followed and modified, there doesn't seem to be many issues. However when the bin directory is followed, the background postgres binaries seem to fail